### PR TITLE
fix: update repo links to use bluetooth-devices

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: ["bdraco"]
+github: ["bluetooth-devices"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fix
 
 
-- Update poetry to v2 + add license to metadata (#34) ([`ebdc785`](https://github.com/bdraco/aiohttp-fast-zlib/commit/ebdc785d60e30b70a7ace0394402d250085a2cf3))
+- Update poetry to v2 + add license to metadata (#34) ([`ebdc785`](https://github.com/bluetooth-devices/aiohttp-fast-zlib/commit/ebdc785d60e30b70a7ace0394402d250085a2cf3))
 
 
 ## v0.2.1 (2024-12-20)
@@ -13,10 +13,10 @@
 ### Fix
 
 
-- Ensure release works if template cannot be rendered (#26) ([`3563232`](https://github.com/bdraco/aiohttp-fast-zlib/commit/3563232f6fad1eb942654104c5bdc9adcfaf5a38))
+- Ensure release works if template cannot be rendered (#26) ([`3563232`](https://github.com/bluetooth-devices/aiohttp-fast-zlib/commit/3563232f6fad1eb942654104c5bdc9adcfaf5a38))
 
 
-- Typos in readme (#25) ([`f202938`](https://github.com/bdraco/aiohttp-fast-zlib/commit/f2029381744a5ba35416b6f755eca65538975d7c))
+- Typos in readme (#25) ([`f202938`](https://github.com/bluetooth-devices/aiohttp-fast-zlib/commit/f2029381744a5ba35416b6f755eca65538975d7c))
 
 
 ### Unknown
@@ -28,7 +28,7 @@
 ### Feature
 
 
-- Add support for aiohttp 3.11+ (#21) ([`9a84c80`](https://github.com/bdraco/aiohttp-fast-zlib/commit/9a84c803da39aae9e4093061ac8c2750f39a28d9))
+- Add support for aiohttp 3.11+ (#21) ([`9a84c80`](https://github.com/bluetooth-devices/aiohttp-fast-zlib/commit/9a84c803da39aae9e4093061ac8c2750f39a28d9))
 
 
 ## v0.1.1 (2024-06-24)
@@ -36,7 +36,7 @@
 ### Fix
 
 
-- Fix license classifier (#4) ([`3759af6`](https://github.com/bdraco/aiohttp-fast-zlib/commit/3759af6a74fd6a00113ecf5f64e116eaccef45bf))
+- Fix license classifier (#4) ([`3759af6`](https://github.com/bluetooth-devices/aiohttp-fast-zlib/commit/3759af6a74fd6a00113ecf5f64e116eaccef45bf))
 
 
 ## v0.1.0 (2024-05-04)
@@ -44,5 +44,5 @@
 ### Feature
 
 
-- Initial commit ([`828aa05`](https://github.com/bdraco/aiohttp-fast-zlib/commit/828aa058775d7c4b585917017d4e699d52d5a92b))
+- Initial commit ([`828aa05`](https://github.com/bluetooth-devices/aiohttp-fast-zlib/commit/828aa058775d7c4b585917017d4e699d52d5a92b))
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,4 +114,4 @@ $ pytest tests
 
 The deployment should be automated and can be triggered from the Semantic Release workflow in GitHub. The next version will be based on [the commit logs](https://python-semantic-release.readthedocs.io/en/latest/commit-log-parsing.html#commit-log-parsing). This is done by [python-semantic-release](https://python-semantic-release.readthedocs.io/en/latest/index.html) via a GitHub action.
 
-[gh-issues]: https://github.com/bdraco/aiohttp-fast-zlib/issues
+[gh-issues]: https://github.com/bluetooth-devices/aiohttp-fast-zlib/issues

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # aiohttp-fast-zlib
 
 <p align="center">
-  <a href="https://github.com/bdraco/aiohttp-fast-zlib/actions/workflows/ci.yml?query=branch%3Amain">
-    <img src="https://img.shields.io/github/actions/workflow/status/bdraco/aiohttp-fast-zlib/ci.yml?branch=main&label=CI&logo=github&style=flat-square" alt="CI Status" >
+  <a href="https://github.com/bluetooth-devices/aiohttp-fast-zlib/actions/workflows/ci.yml?query=branch%3Amain">
+    <img src="https://img.shields.io/github/actions/workflow/status/bluetooth-devices/aiohttp-fast-zlib/ci.yml?branch=main&label=CI&logo=github&style=flat-square" alt="CI Status" >
   </a>
-  <a href="https://codecov.io/gh/bdraco/aiohttp-fast-zlib">
-    <img src="https://img.shields.io/codecov/c/github/bdraco/aiohttp-fast-zlib.svg?logo=codecov&logoColor=fff&style=flat-square" alt="Test coverage percentage">
+  <a href="https://codecov.io/gh/bluetooth-devices/aiohttp-fast-zlib">
+    <img src="https://img.shields.io/codecov/c/github/bluetooth-devices/aiohttp-fast-zlib.svg?logo=codecov&logoColor=fff&style=flat-square" alt="Test coverage percentage">
   </a>
 </p>
 <p align="center">
@@ -29,7 +29,7 @@
 
 ---
 
-**Source Code**: <a href="https://github.com/bdraco/aiohttp-fast-zlib" target="_blank">https://github.com/bdraco/aiohttp-fast-zlib </a>
+**Source Code**: <a href="https://github.com/bluetooth-devices/aiohttp-fast-zlib" target="_blank">https://github.com/bluetooth-devices/aiohttp-fast-zlib </a>
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,9 @@ requires-python = ">=3.9"
 dynamic = ["classifiers", "dependencies", "optional-dependencies"]
 
 [project.urls]
-"Repository" = "https://github.com/bdraco/aiohttp-fast-zlib"
-"Bug Tracker" = "https://github.com/bdraco/aiohttp-fast-zlib/issues"
-"Changelog" = "https://github.com/bdraco/aiohttp-fast-zlib/blob/main/CHANGELOG.md"
+"Repository" = "https://github.com/bluetooth-devices/aiohttp-fast-zlib"
+"Bug Tracker" = "https://github.com/bluetooth-devices/aiohttp-fast-zlib/issues"
+"Changelog" = "https://github.com/bluetooth-devices/aiohttp-fast-zlib/blob/main/CHANGELOG.md"
 
 [tool.poetry]
 classifiers = [


### PR DESCRIPTION
I have been transferring some of the projects that are under my person GitHub to OHF repos since it was hard for other contributors to help out with projects that were hosted on my personal GitHub. Bluetooth-devices has a lot of people I trust so I picked that org even though the fit is a bit strange.  We could later transfer it to home-assistant-libs if desired.